### PR TITLE
Only require dotenv in test env

### DIFF
--- a/lib/blockfrost-ruby.rb
+++ b/lib/blockfrost-ruby.rb
@@ -5,8 +5,6 @@
 # require 'blockfrost-ruby'
 # blockfrost = Blockfrostruby::CardanoMainNet.new()
 
-require 'dotenv/load'
-
 require_relative 'blockfrostruby/version'
 require_relative 'blockfrostruby/constants'
 require_relative 'blockfrostruby/configuration'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'dotenv/load'
 require 'blockfrost-ruby'
 
 RSpec.configure do |config|


### PR DESCRIPTION
with commit https://github.com/blockfrost/blockfrost-ruby/commit/d3a7239f4139692245f30702aa832a4f1f7ed1f0 dotenv became an inherited and implicit hard dependency for any project depending on blockfrost-ruby.

Since dotenv is only needed within the test environment, moving it into `spec_helper` releases the dependency for projects depending on blockfrost-ruby and makes sure it only gets required in this library's test environment.